### PR TITLE
Fix crash error

### DIFF
--- a/src/seekers/__init__.py
+++ b/src/seekers/__init__.py
@@ -12,5 +12,5 @@ except ImportError:
 
 from .seeker import SubtitlesDownloadError, SubtitlesSearchError, SubtitlesErrors
 from .xbmc_subtitles import TitulkyComSeeker, \
-    OpenSubtitlesSeeker, OpenSubtitlesMoraSeeker, OpenSubtitles2Seeker, SubdlSeeker, SubsytsSeeker, SubtitlecatSeeker, MoviesubtitlesSeeker, IndexsubtitleSeeker, YtssubsSeeker, FoursubSeeker, PodnapisiSeeker, SubscenebestSeeker, LocalDriveSeeker, Sub_Scene_comSeeker, SubtitlesmoraSeeker, \
+    OpenSubtitlesMoraSeeker, OpenSubtitles2Seeker, SubdlSeeker, SubsytsSeeker, SubtitlecatSeeker, MoviesubtitlesSeeker, IndexsubtitleSeeker, YtssubsSeeker, FoursubSeeker, PodnapisiSeeker, SubscenebestSeeker, LocalDriveSeeker, Sub_Scene_comSeeker, SubtitlesmoraSeeker, \
      TitloviSeeker, PrijevodiOnlineSeeker, MySubsSeeker, SubsourceSeeker, NovalermoraSeeker, ElsubtitleSeeker


### PR DESCRIPTION
2025-07-18 13:24:27+0300 [-]   File "/usr/lib/enigma2/python/Plugins/Extensions/SubsSupport/seekers/__init__.py", line 14, in <module>
2025-07-18 13:24:27+0300 [-]     from .xbmc_subtitles import TitulkyComSeeker, \
2025-07-18 13:24:27+0300 [-]         OpenSubtitlesSeeker, OpenSubtitlesMoraSeeker, OpenSubtitles2Seeker, SubdlSeeker, SubsytsSeeker, SubtitlecatSeeker, MoviesubtitlesSeeker, IndexsubtitleSeeker, YtssubsSeeker, FoursubSeeker, PodnapisiSeeker, SubscenebestSeeker, LocalDriveSeeker, Sub_Scene_comSeeker, SubtitlesmoraSeeker, \
2025-07-18 13:24:27+0300 [-]          TitloviSeeker, PrijevodiOnlineSeeker, MySubsSeeker, SubsourceSeeker, NovalermoraSeeker, ElsubtitleSeeker
2025-07-18 13:24:27+0300 [-] ImportError: cannot import name 'OpenSubtitlesSeeker' from 'Plugins.Extensions.SubsSupport.seekers.xbmc_subtitles' (/usr/lib/enigma2/python/Plugins/Extensions/SubsSupport/seekers/xbmc_subtitles.py)